### PR TITLE
Remove blank card from Divisions pages

### DIFF
--- a/web/themes/custom/oc_bootstrap/css/style.css
+++ b/web/themes/custom/oc_bootstrap/css/style.css
@@ -938,3 +938,7 @@ article.teaser h2 a {
   margin-right: 10px;
   margin-top: 20px;
 }
+
+.division {
+  display: none;
+}


### PR DESCRIPTION
I've added "display: none" to the .division class, I've checked the rest of the site and it doesn't seem to affect anything else:

![Screenshot 2021-03-15 at 11 24 48 (2)](https://user-images.githubusercontent.com/58986635/111146774-b6423600-8581-11eb-8a2e-34aed9add84b.png) 