### PR TITLE
Banner image positions tweaks/removal of full job page banner border

### DIFF
--- a/web/themes/custom/oc_bootstrap/css/style.css
+++ b/web/themes/custom/oc_bootstrap/css/style.css
@@ -246,6 +246,7 @@ a.logo.navbar-btn img {
 .page-node-type-job .banner-wrapper {
   height: initial;
   background: none;
+  border-bottom: none;
 }
 .page-node-type-job .banner-wrapper .banner {
   padding-bottom: 150px;

--- a/web/themes/custom/oc_bootstrap/css/style.css
+++ b/web/themes/custom/oc_bootstrap/css/style.css
@@ -189,7 +189,7 @@ a.logo.navbar-btn img {
 @media screen and (max-width: 1700px) {
   .path-testimonials .banner-wrapper {
     background-size: 100%;
-    background-position-y: -500px;
+    background-position-y: -460px;
   }
 }
 
@@ -210,7 +210,7 @@ a.logo.navbar-btn img {
 @media screen and (max-width: 1700px) {
   .path-about .banner-wrapper {
     background-size: 100%;
-    background-position-y: 500px;
+    background-position-y: 530px;
   }
 }
 
@@ -268,7 +268,7 @@ a.logo.navbar-btn img {
   .banner-wrapper.image-truck {
     background: url(../images/workers.png);
     background-size: 100%;
-    background-position-y: 800px;
+    background-position-y: 740px;
   }
 }
 


### PR DESCRIPTION
Changed background y position on About Us, Jobs and Testimonials banners as per JE request:

![Screenshot 2021-03-18 at 11 58 45 (2)](https://user-images.githubusercontent.com/58986635/111624014-0c61e400-87e3-11eb-9098-40f6fcf3adcc.png)

![Screenshot 2021-03-18 at 11 59 59 (2)](https://user-images.githubusercontent.com/58986635/111624028-108e0180-87e3-11eb-8114-cebb884adeb3.png)

![Screenshot 2021-03-18 at 12 04 29 (2)](https://user-images.githubusercontent.com/58986635/111624035-1388f200-87e3-11eb-81fb-63298f5323c3.png)